### PR TITLE
PATHS: fix for demo names that contain multiple periods in a row

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -145,6 +145,6 @@ const char *FS_FileExtension (const char *in)
 // absolute paths are prohibited
 qbool FS_SafePath(const char *in)
 {
-	return ( (in[0] == '\\' || in[0] == '/' || strstr(in, "..") || (in[0] && in[1] == ':')) ? false : true );
+	return ( (in[0] == '\\' || in[0] == '/' || strstr(in, "../") || strstr(in, "..\\") || (in[0] && in[1] == ':')) ? false : true );
 }
 


### PR DESCRIPTION
PATHS: when getting a clean path check for ../ and ..\ instead of only .. as these are valid characters in player names and may be contained in demo filenames