### PR TITLE
Add demo_filenames.txt endpoint to http server.

### DIFF
--- a/src/httpsv.c
+++ b/src/httpsv.c
@@ -528,9 +528,9 @@ void HTTPSV_GetMethod(cluster_t *cluster, oproxy_t *pend)
 	{
 		HTTPSV_GenerateDemoListing(cluster, pend);
 	}
-	else if (URLCOMPARE(getpath, "/demo_filenames.txt", skiplen))
+	else if (URLCOMPARE(getpath, "/demo_filenames", skiplen))
 	{
-		HTTPSV_GenerateDemoFilenamesTxt(cluster, pend);
+		HTTPSV_GenerateDemoFilenames(cluster, pend);
 	}
 	else if (!strcmp(getpath, "/style.css"))
 	{

--- a/src/httpsv.c
+++ b/src/httpsv.c
@@ -528,6 +528,10 @@ void HTTPSV_GetMethod(cluster_t *cluster, oproxy_t *pend)
 	{
 		HTTPSV_GenerateDemoListing(cluster, pend);
 	}
+	else if (URLCOMPARE(getpath, "/demo_filenames.txt", skiplen))
+	{
+		HTTPSV_GenerateDemoFilenamesTxt(cluster, pend);
+	}
 	else if (!strcmp(getpath, "/style.css"))
 	{
 		HTTPSV_GenerateCSSFile(cluster, pend);

--- a/src/httpsv_generate.c
+++ b/src/httpsv_generate.c
@@ -704,6 +704,22 @@ void HTTPSV_GenerateDemoListing(cluster_t *cluster, oproxy_t *dest)
 	HTTPSV_SendHTMLFooter(cluster, dest);
 }
 
+void HTTPSV_GenerateDemoFilenamesTxt(cluster_t *cluster, oproxy_t *dest)
+{
+	dest->_bufferautoadjustmaxsize_ = 1024 * 1024; // NOTE: this allow 1MB buffer...
+	char row_buf[1024];
+	int i;	
+
+	HTTPSV_SendHTTPHeader(cluster, dest, "200", "text/plain", true);
+
+	Cluster_BuildAvailableDemoList(cluster);
+	for (i = 0; i < cluster->availdemoscount; i++)
+	{
+		snprintf(row_buf, sizeof(row_buf), "%s%s", cluster->availdemos[i].name, CRLF);
+		Net_ProxySend(cluster, dest, row_buf, strlen(row_buf));
+	}
+}
+
 void HTTPSV_GenerateImage(cluster_t *cluster, oproxy_t *dest, char *imgfilename)
 {
 	int s;

--- a/src/httpsv_generate.c
+++ b/src/httpsv_generate.c
@@ -704,19 +704,25 @@ void HTTPSV_GenerateDemoListing(cluster_t *cluster, oproxy_t *dest)
 	HTTPSV_SendHTMLFooter(cluster, dest);
 }
 
-void HTTPSV_GenerateDemoFilenamesTxt(cluster_t *cluster, oproxy_t *dest)
+void HTTPSV_GenerateDemoFilenames(cluster_t *cluster, oproxy_t *dest)
 {
-	dest->_bufferautoadjustmaxsize_ = 1024 * 1024; // NOTE: this allow 1MB buffer...
 	char row_buf[1024];
-	int i;	
+	int i;
+
+	if (dest != NULL) {
+		dest->_bufferautoadjustmaxsize_ = 1024 * 1024; // NOTE: this allow 1MB buffer...
+	}
 
 	HTTPSV_SendHTTPHeader(cluster, dest, "200", "text/plain", true);
 
 	Cluster_BuildAvailableDemoList(cluster);
-	for (i = 0; i < cluster->availdemoscount; i++)
-	{
-		snprintf(row_buf, sizeof(row_buf), "%s%s", cluster->availdemos[i].name, CRLF);
-		Net_ProxySend(cluster, dest, row_buf, strlen(row_buf));
+
+	if (cluster != NULL) {
+		for (i = 0; i < cluster->availdemoscount; i++)
+		{
+			snprintf(row_buf, sizeof(row_buf), "%s%s", cluster->availdemos[i].name, CRLF);
+			Net_ProxySend(cluster, dest, row_buf, strlen(row_buf));
+		}
 	}
 }
 

--- a/src/qtv.h
+++ b/src/qtv.h
@@ -1069,6 +1069,7 @@ void			HTTPSV_GenerateQTVStub(cluster_t *cluster, oproxy_t *dest, char *streamty
 void			HTTPSV_GenerateQTVJoinStub(cluster_t *cluster, oproxy_t *dest, char *streamid);
 void			HTTPSV_GenerateAdmin(cluster_t *cluster, oproxy_t *dest, int streamid, char *postbody);
 void			HTTPSV_GenerateDemoListing(cluster_t *cluster, oproxy_t *dest);
+void			HTTPSV_GenerateDemoFilenamesTxt(cluster_t *cluster, oproxy_t *dest);
 void			HTTPSV_GenerateImage(cluster_t *cluster, oproxy_t *dest, char *imgfilename);
 void			HTTPSV_GenerateLevelshot(cluster_t *cluster, oproxy_t *dest, char *name);
 void			HTTPSV_GenerateDemoDownload(cluster_t *cluster, oproxy_t *dest, char *name);

--- a/src/qtv.h
+++ b/src/qtv.h
@@ -1069,7 +1069,7 @@ void			HTTPSV_GenerateQTVStub(cluster_t *cluster, oproxy_t *dest, char *streamty
 void			HTTPSV_GenerateQTVJoinStub(cluster_t *cluster, oproxy_t *dest, char *streamid);
 void			HTTPSV_GenerateAdmin(cluster_t *cluster, oproxy_t *dest, int streamid, char *postbody);
 void			HTTPSV_GenerateDemoListing(cluster_t *cluster, oproxy_t *dest);
-void			HTTPSV_GenerateDemoFilenamesTxt(cluster_t *cluster, oproxy_t *dest);
+void			HTTPSV_GenerateDemoFilenames(cluster_t *cluster, oproxy_t *dest);
 void			HTTPSV_GenerateImage(cluster_t *cluster, oproxy_t *dest, char *imgfilename);
 void			HTTPSV_GenerateLevelshot(cluster_t *cluster, oproxy_t *dest, char *name);
 void			HTTPSV_GenerateDemoDownload(cluster_t *cluster, oproxy_t *dest, char *name);


### PR DESCRIPTION
Allow requesting a list of demo filenames (`/demo_filenames.txt`). Currently everyone need to parse a large chunk of HTML to get a hold of the demo filenames.

Example
![image](https://user-images.githubusercontent.com/1616817/198314322-e71ee06e-f4f0-43dc-95d3-7bf5c56b4849.png)
