### PR TITLE
PROTOCOL: Update to gameplay protocol extensions.

### DIFF
--- a/src/cl_cmds.c
+++ b/src/cl_cmds.c
@@ -819,7 +819,7 @@ static void Clcmd_New_f(sv_t *qtv, oproxy_t *prox)
 }
 */
 
-static void Clcmd_send_list(sv_t *qtv, oproxy_t *prox, int svc)
+static void Clcmd_send_list(sv_t *qtv, oproxy_t *prox, filename_t *list, int svc, int svc_extended)
 {
 	char buffer[MAX_MSGLEN*8];
 	netmsg_t msg;
@@ -844,7 +844,7 @@ static void Clcmd_send_list(sv_t *qtv, oproxy_t *prox, int svc)
 
 	for (prespawn = 0;prespawn >= 0;)
 	{
-		prespawn = SendList(qtv, prespawn, svc == svc_soundlist ? qtv->soundlist : qtv->modellist, svc, &msg);
+		prespawn = SendList(qtv, prespawn, list, svc, svc_extended, &msg);
 		Prox_SendMessage(&g_cluster, prox, msg.data, msg.cursize, dem_read, (unsigned)-1);
 		msg.cursize = 0;
 	}
@@ -866,7 +866,7 @@ static void Clcmd_Soundlist_f(sv_t *qtv, oproxy_t *prox)
 		return;
 	}
 
-	Clcmd_send_list(qtv, prox, svc_soundlist);
+	Clcmd_send_list(qtv, prox, qtv->soundlist, svc_soundlist, svc_fte_soundlistshort_UNUSED);
 }
 
 static void Clcmd_Modellist_f(sv_t *qtv, oproxy_t *prox)
@@ -877,7 +877,7 @@ static void Clcmd_Modellist_f(sv_t *qtv, oproxy_t *prox)
 		return;
 	}
 
-	Clcmd_send_list(qtv, prox, svc_modellist);
+	Clcmd_send_list(qtv, prox, qtv->modellist, svc_modellist, svc_fte_modellistshort);
 }
 
 static void Clcmd_Spawn_f(sv_t *qtv, oproxy_t *prox)

--- a/src/forward.c
+++ b/src/forward.c
@@ -328,14 +328,14 @@ void Net_SendConnectionMVD_1_0(sv_t *qtv, oproxy_t *prox)
 
 	for (prespawn = 0;prespawn >= 0;)
 	{
-		prespawn = SendList(qtv, prespawn, qtv->soundlist, svc_soundlist, &msg);
+		prespawn = SendList(qtv, prespawn, qtv->soundlist, svc_soundlist, svc_fte_soundlistshort_UNUSED, &msg);
 		Prox_SendMessage(&g_cluster, prox, msg.data, msg.cursize, dem_read, (unsigned)-1);
 		msg.cursize = 0;
 	}
 
 	for (prespawn = 0;prespawn >= 0;)
 	{
-		prespawn = SendList(qtv, prespawn, qtv->modellist, svc_modellist, &msg);
+		prespawn = SendList(qtv, prespawn, qtv->modellist, svc_modellist, svc_fte_modellistshort, &msg);
 		Prox_SendMessage(&g_cluster, prox, msg.data, msg.cursize, dem_read, (unsigned)-1);
 		msg.cursize = 0;
 	}

--- a/src/qconst.h
+++ b/src/qconst.h
@@ -20,13 +20,12 @@
 #define MAX_USERINFO			192
 #define MAX_INFO_KEY 			64
 
-#define MAX_LIST	256
-#define MAX_MODELS	MAX_LIST
-#define MAX_SOUNDS	MAX_LIST
-#define MAX_ENTITIES		512
-#define MAX_STATICSOUNDS	64
-#define MAX_STATICENTITIES	128
 #define MAX_LIGHTSTYLES		64
+#define MAX_ENTITIES		2048
+#define MAX_STATICENTITIES	2048
+#define MAX_MODELS			(MAX_ENTITIES + MAX_STATICENTITIES)
+#define MAX_STATICSOUNDS	256
+#define MAX_SOUNDS			256
 
 #define MAX_ENTITY_FRAMES	64
 
@@ -63,6 +62,8 @@
 #define	U_FRAME		(1<<13)
 #define	U_REMOVE	(1<<14)		// REMOVE this entity, don't add it
 #define	U_MOREBITS	(1<<15)
+#define U_FTE_EVENMORE	(1<<7)
+#define U_FTE_YETMORE	(1<<7)
 
 // if MOREBITS is set, these additional flags are read in next
 #define	U_ANGLE1	(1<<0)
@@ -72,6 +73,13 @@
 #define	U_SKIN		(1<<4)
 #define	U_EFFECTS	(1<<5)
 #define	U_SOLID		(1<<6)		// the entity should be solid for prediction
+
+// if EVENMORE is set
+#define U_FTE_MODELDBL   (1<<3)
+#define U_FTE_ENTITYDBL  (1<<5)
+#define U_FTE_ENTITYDBL2 (1<<6)
+#define U_FTE_TRANS      (1<<1)
+#define U_FTE_COLOURMOD  (1<<10)
 
 //======================================
 //flags on players in mvds

--- a/src/svc.h
+++ b/src/svc.h
@@ -31,7 +31,7 @@ SVC(svc_spawnstatic)
 
 // 21-30
 
-SVC(svc_spawnstatic2_UNUSED)
+SVC(svc_fte_spawnstatic2)
 SVC(svc_spawnbaseline)
 
 SVC(svc_temp_entity)			// variable
@@ -91,17 +91,17 @@ SVC(svc_updatepl)				// [qbyte] [qbyte]
 SVC(svc_nails2)					// qwe - [qbyte] num [52 bits] nxyzpy 8 12 12 12 4 8
 
 SVC(svc_unused_55)
-SVC(svc_unused_56)
+SVC(svc_fte_soundlistshort_UNUSED)
 SVC(svc_unused_57)
 SVC(svc_unused_58)
 SVC(svc_unused_59)
-SVC(svc_unused_60)
+SVC(svc_fte_modellistshort)
 SVC(svc_unused_61)
 SVC(svc_unused_62)
 SVC(svc_unused_63)
 SVC(svc_unused_64)
 SVC(svc_unused_65)
-SVC(svc_unused_66)
+SVC(svc_fte_spawnbaseline2)
 SVC(svc_unused_67)
 SVC(svc_unused_68)
 SVC(svc_unused_69)


### PR DESCRIPTION
Aligns QTV to currently enabled gameplay extensions:

* PEXT_SPAWNSTATIC2 - Delta spawns for extended attributes
  * svc_fte_spawnstatic2
  * svc_fte_spawnbaseline2
* PEXT_ENTITYDBL - Up to 1024 entities
* PEXT_ENTITYDBL2 - Up to 2048 entities
* PEXT_MODELDBL - Up to uint16 model indices
  * svc_fte_modellistshort
* PEXT_TRANS - 1 byte alpha field on entities
* PEXT_COLOURMOD - 3 byte colourmod on entities

Watching a stream of with alpha will require an ezQuake version newer than 2013, and if colormod is used, clients need to be 3.6.6 or newer. For alpha brushes to actually render correctly ezQuake 3.6.6 or newer needs to be used.