### PR TITLE
fix: corrected typo in Ent bits parsing (uFteYetMore)

### DIFF
--- a/pkg/qtv/protocol_reader.go
+++ b/pkg/qtv/protocol_reader.go
@@ -390,7 +390,7 @@ func (qp *qProtocol) readEntityNum() (entNum uint, flags uint, moreflags uint) {
 		flags |= uint(qp.r.GetByte())
 		if (flags & uFteEvenMore) != 0 {
 			moreflags |= uint(qp.r.GetByte())
-			if (moreflags & uFteEvenMore) != 0 {
+			if (moreflags & uFteYetMore) != 0 {
 				moreflags |= uint(qp.r.GetByte()) << 8
 			}
 


### PR DESCRIPTION
Replaced uFteEvenMore with uFteYetMore as suggested in issue #15.
This fixes a minor typo in the Ent bits parsing logic.
fixes #15 