### PR TITLE
fix(security): prevent path traversal in download command

### DIFF
--- a/pkg/qtv/downstream_client_commands.go
+++ b/pkg/qtv/downstream_client_commands.go
@@ -400,6 +400,8 @@ func (ds *dStream) downloadClientCmd(tr *tokenizerResult) (err error) {
 	}
 
 	name := tr.Argv(1)
+	name = strings.ReplaceAll(name, "\\", "/") // Normalize separators (prevent path traversal)
+	name = strings.ToLower(name)
 	gameDir := us.gameDir()
 
 	allow := false
@@ -415,8 +417,6 @@ func (ds *dStream) downloadClientCmd(tr *tokenizerResult) (err error) {
 		err = nil
 		goto denyDownload
 	}
-	name = strings.ReplaceAll(name, "\\", "/")
-	name = strings.ToLower(name)
 
 	if !us.qtv.qvs.Get("allow_download").Bool {
 		// Download is not allowed at all.


### PR DESCRIPTION
Normalize backslashes to forward slashes before calling `qfs.BasePath` so paths like `skins/\..\..\qtv.cfg` cannot escape the allowed download directories.