### PR TITLE
ci: upload built binary and checksum as workflow artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,8 @@ jobs:
         with:
           name: qtv-${{ matrix.target }}
           path: |
-            qtv.*
+            build/${{ matrix.target }}/qtv${{ matrix.ext }}
+            build/${{ matrix.target }}/qtv${{ matrix.ext }}.md5
           compression-level: 9
 
   upload:


### PR DESCRIPTION
Fix the upload-artifact path which pointed at a non-matching 'qtv.*' glob; point it at the actual build output instead.